### PR TITLE
chore: downgrade CLI version and adjust SQL queries to remove 'raw_' pre…

### DIFF
--- a/visivo/project.visivo.yml
+++ b/visivo/project.visivo.yml
@@ -1,6 +1,6 @@
 path: project
 name: CFPB Complaints Analytics
-cli_version: 1.0.75
+cli_version: 1.0.72
 includes: []
 destinations: []
 alerts: []
@@ -23,7 +23,7 @@ models:
         pct_disputed,
         pct_timely,
         avg_days_to_response
-      FROM raw_marts.dim_companies
+      FROM marts.dim_companies
       ORDER BY total_complaints DESC
       LIMIT 20
 
@@ -37,7 +37,7 @@ models:
         pct_timely,
         pct_disputed,
         avg_days_to_response
-      FROM raw_marts.agg_complaints_by_month
+      FROM marts.agg_complaints_by_month
       ORDER BY complaint_month_date
 
   # State distribution
@@ -49,7 +49,7 @@ models:
         total_complaints,
         pct_disputed,
         pct_timely
-      FROM raw_marts.dim_states
+      FROM marts.dim_states
       ORDER BY total_complaints DESC
       LIMIT 25
 


### PR DESCRIPTION
Closing #1 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Point models from `raw_marts` to `marts` tables and set Visivo CLI to 1.0.72.
> 
> - **Data models**:
>   - Switch SQL `FROM` sources from `raw_marts.*` to `marts.*` in `company_metrics`, `monthly_trends`, and `state_distribution`.
> - **Config**:
>   - Set Visivo `cli_version` to `1.0.72` in `visivo/project.visivo.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 243840d857420eeea3106d09ad37afabf83e7632. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->