### PR TITLE
feat: Add parquet landing area for staging extracted data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,7 @@ database/cfpb_complaints.duckdb.wal
 
 *.duckdb
 *.db
+
+# Landing area (parquet data files)
+landing/*
+!landing/.gitkeep

--- a/docs/PYARROW.md
+++ b/docs/PYARROW.md
@@ -1,0 +1,56 @@
+# Why PyArrow?
+
+## Role in the Pipeline
+
+PyArrow is used to write and read **Parquet files** in the landing area (`landing/cfpb_complaints/`). It serves as the bridge between API extraction and DuckDB loading.
+
+```text
+CFPB API → extract_complaints() → PyArrow writes Parquet → PyArrow reads Parquet → dlt loads to DuckDB
+```
+
+## Why Parquet?
+
+- **Columnar format**: Efficient storage and fast analytical reads
+- **Schema preservation**: Data types are encoded in the file, no CSV parsing ambiguity
+- **Compression**: Parquet files are significantly smaller than JSON/CSV equivalents
+- **DuckDB native support**: DuckDB can read Parquet files directly via `read_parquet()`
+
+## Why PyArrow (vs alternatives)?
+
+| Option      | Pros                                                                               | Cons                                           |
+| ----------- | ---------------------------------------------------------------------------------- | ---------------------------------------------- |
+| **PyArrow** | Zero new dependencies (transitive dep of dlt + duckdb), fast, full Parquet support | Slightly verbose API                           |
+| pandas      | Familiar API                                                                       | Would add a heavy dependency just for file I/O |
+| fastparquet | Lightweight                                                                        | Extra dependency, less maintained              |
+| DuckDB COPY | No Python intermediary                                                             | Doesn't help with writing from API data        |
+
+PyArrow is already installed as a transitive dependency of both `dlt` and `duckdb`, so it adds **zero additional packages** to the project.
+
+## Usage in the Codebase
+
+### Writing (`save_to_parquet`)
+
+```python
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+table = pa.Table.from_pylist(records)
+pq.write_table(table, file_path)
+```
+
+### Reading (`load_parquet_to_duckdb`)
+
+```python
+table = pq.read_table(parquet_path)
+records = table.to_pylist()
+```
+
+## File Location
+
+Parquet files are written to:
+
+```text
+landing/cfpb_complaints/{company}_{date_min}_{date_max}.parquet
+```
+
+These files are gitignored and serve as a local staging area for debugging, archival, and replayability.

--- a/src/orchestration/cfpb_flows.py
+++ b/src/orchestration/cfpb_flows.py
@@ -69,7 +69,7 @@ def load_parquet_to_duckdb_task(
         parquet_path=parquet_path,
         database_path=database_path,
     )
-    logger.info(f"Completed loading parquet into DuckDB")
+    logger.info("Completed loading parquet into DuckDB")
     return {
         "status": "success",
         "parquet_path": parquet_path,
@@ -230,7 +230,9 @@ def cfpb_complaints_incremental_flow(
             "last_date": date_max,
         }
 
-    logger.info(f"Loading data for {len(COMPANIES)} companies from {date_min} to {date_max}")
+    logger.info(
+        f"Loading data for {len(COMPANIES)} companies from {date_min} to {date_max}"
+    )
 
     # Extract to parquet, then load into DuckDB for each company
     results = []

--- a/src/orchestration/cfpb_flows.py
+++ b/src/orchestration/cfpb_flows.py
@@ -17,55 +17,63 @@ from typing import Any
 from prefect import flow, task
 
 from ..cfg.config import COMPANIES, START_DATE
-from ..pipelines.cfpb_complaints_pipeline import create_pipeline, extract_complaints
+from ..pipelines.cfpb_complaints_pipeline import load_parquet_to_duckdb, save_to_parquet
 from ..utils.state import get_next_load_date, update_last_loaded_date
 
 logger = logging.getLogger(__name__)
 
 
-@task(name="extract_and_load_complaints", log_prints=True)
-
-# create_pipeline() (DuckDB connection)
-# extract_complaints() (API call)
-# pipeline.run(....) (load to DuckDB)
-
-
-def extract_and_load_complaints_task(
+@task(name="extract_to_parquet", log_prints=True)
+def extract_to_parquet_task(
     date_min: str,
     date_max: str,
     company_name: str,
-    database_path: str = "database/cfpb_complaints.duckdb",
-) -> dict[str, Any]:
+) -> str | None:
     """
-    Prefect task to extract and load complaints for a company.
+    Prefect task to extract complaints and save as parquet.
 
     Args:
         date_min: Minimum received date (YYYY-MM-DD)
         date_max: Maximum received date (YYYY-MM-DD)
         company_name: Company name to filter
+
+    Returns:
+        Path to the parquet file, or None if no records
+    """
+    logger.info(f"Extracting complaints for {company_name}: {date_min} to {date_max}")
+    parquet_path = save_to_parquet(
+        date_received_min=date_min,
+        date_received_max=date_max,
+        company_name=company_name,
+    )
+    return parquet_path
+
+
+@task(name="load_parquet_to_duckdb", log_prints=True)
+def load_parquet_to_duckdb_task(
+    parquet_path: str,
+    database_path: str = "database/cfpb_complaints.duckdb",
+) -> dict[str, Any]:
+    """
+    Prefect task to load a parquet file into DuckDB.
+
+    Args:
+        parquet_path: Path to the parquet file
         database_path: Path to DuckDB database file
 
     Returns:
         Dictionary with execution results
     """
-    logger.info(f"Loading complaints for {company_name}: {date_min} to {date_max}")
-
-    pipeline = create_pipeline(database_path=database_path)
-
-    info = pipeline.run(
-        extract_complaints(
-            date_received_min=date_min,
-            date_received_max=date_max,
-            company_name=company_name,
-        )
+    logger.info(f"Loading parquet {parquet_path} into DuckDB")
+    result = load_parquet_to_duckdb(
+        parquet_path=parquet_path,
+        database_path=database_path,
     )
-
-    logger.info(f"Completed loading for {company_name}")
+    logger.info(f"Completed loading parquet into DuckDB")
     return {
-        "company": company_name,
         "status": "success",
-        "date_range": f"{date_min} to {date_max}",
-        "info": str(info),
+        "parquet_path": parquet_path,
+        **result,
     }
 
 
@@ -224,16 +232,32 @@ def cfpb_complaints_incremental_flow(
 
     logger.info(f"Loading data for {len(COMPANIES)} companies from {date_min} to {date_max}")
 
-    # Load data for each company
+    # Extract to parquet, then load into DuckDB for each company
     results = []
     for company in COMPANIES:
         try:
-            result = extract_and_load_complaints_task(
+            parquet_path = extract_to_parquet_task(
                 date_min=date_min,
                 date_max=date_max,
                 company_name=company,
+            )
+            if parquet_path is None:
+                logger.info(f"No data extracted for {company}, skipping load")
+                results.append(
+                    {
+                        "company": company,
+                        "status": "success",
+                        "date_range": f"{date_min} to {date_max}",
+                        "info": "No records found",
+                    }
+                )
+                continue
+            result = load_parquet_to_duckdb_task(
+                parquet_path=parquet_path,
                 database_path=database_path,
             )
+            result["company"] = company
+            result["date_range"] = f"{date_min} to {date_max}"
             results.append(result)
         except Exception as e:
             logger.error(f"Failed to load data for {company}: {e}")

--- a/src/orchestration/cfpb_flows.py
+++ b/src/orchestration/cfpb_flows.py
@@ -230,9 +230,7 @@ def cfpb_complaints_incremental_flow(
             "last_date": date_max,
         }
 
-    logger.info(
-        f"Loading data for {len(COMPANIES)} companies from {date_min} to {date_max}"
-    )
+    logger.info(f"Loading data for {len(COMPANIES)} companies from {date_min} to {date_max}")
 
     # Extract to parquet, then load into DuckDB for each company
     results = []

--- a/src/pipelines/cfpb_complaints_pipeline.py
+++ b/src/pipelines/cfpb_complaints_pipeline.py
@@ -7,12 +7,15 @@ and loads it into DuckDB in the raw schema.
 
 import hashlib
 import logging
+import re
 from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import dlt
+import pyarrow as pa
+import pyarrow.parquet as pq
 from dlt.destinations import duckdb
 
 from ..apis.cfpb_api_client import CFPBAPIClient
@@ -91,6 +94,93 @@ def extract_complaints(
 
     finally:
         client.close()
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize a string for use in filenames."""
+    return re.sub(r"[^a-z0-9_]", "_", name.lower().strip())
+
+
+def save_to_parquet(
+    date_received_min: str,
+    date_received_max: str,
+    company_name: str,
+    landing_dir: str = "landing/cfpb_complaints",
+    max_records: int | None = None,
+) -> str | None:
+    """
+    Extract complaints from the CFPB API and save as a parquet file.
+
+    Args:
+        date_received_min: Minimum received date (YYYY-MM-DD)
+        date_received_max: Maximum received date (YYYY-MM-DD)
+        company_name: Company name to filter
+        landing_dir: Directory to write parquet files
+        max_records: Maximum number of records to fetch
+
+    Returns:
+        Path to the written parquet file, or None if no records were extracted.
+    """
+    records = list(
+        extract_complaints(
+            date_received_min=date_received_min,
+            date_received_max=date_received_max,
+            company_name=company_name,
+            max_records=max_records,
+        )
+    )
+
+    if not records:
+        logger.info(f"No records extracted for {company_name}, skipping parquet write")
+        return None
+
+    table = pa.Table.from_pylist(records)
+
+    landing_path = Path(landing_dir)
+    landing_path.mkdir(parents=True, exist_ok=True)
+
+    safe_company = _sanitize_filename(company_name)
+    filename = f"{safe_company}_{date_received_min}_{date_received_max}.parquet"
+    file_path = landing_path / filename
+
+    pq.write_table(table, file_path)
+    logger.info(f"Wrote {len(records)} records to {file_path}")
+    return str(file_path)
+
+
+def load_parquet_to_duckdb(
+    parquet_path: str,
+    database_path: str = "database/cfpb_complaints.duckdb",
+    schema_name: str = "raw",
+) -> dict[str, Any]:
+    """
+    Load a parquet file into DuckDB via dlt (preserves merge/dedup logic).
+
+    Args:
+        parquet_path: Path to the parquet file to load
+        database_path: Path to DuckDB database file
+        schema_name: Schema name for the data
+
+    Returns:
+        Dictionary with load info
+    """
+    table = pq.read_table(parquet_path)
+    records = table.to_pylist()
+    logger.info(f"Read {len(records)} records from {parquet_path}")
+
+    pipeline = create_pipeline(database_path=database_path, schema_name=schema_name)
+
+    @dlt.resource(
+        name="cfpb_complaints",
+        write_disposition="merge",
+        primary_key="complaint_id",
+    )
+    def parquet_source() -> Iterator[dict[str, Any]]:
+        yield from records
+
+    info = pipeline.run(parquet_source())
+    logger.info(f"Loaded {len(records)} records from parquet into DuckDB")
+    return {"records_loaded": len(records), "info": str(info)}
 
 
 def create_pipeline(


### PR DESCRIPTION
## Summary
- Added a parquet landing area (`landing/cfpb_complaints/`) between API extraction and DuckDB loading for debugging, archival, and replayability
- Split the single `extract_and_load_complaints_task` into two tasks: `extract_to_parquet_task` and `load_parquet_to_duckdb_task`
- DuckDB loading still uses dlt with merge/dedup logic, just reads from parquet instead of directly from the API

## Test plan
- [ ] Run `uv run python run_prefect_flow.py --reset-state` and verify parquet files appear in `landing/cfpb_complaints/`
- [ ] Verify DuckDB raw schema still has data after the flow completes
- [ ] Run `uv run pytest tests/` to confirm existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ingestion execution path by introducing file-based staging and a two-step Prefect task flow, which could affect load completeness and operational behavior (e.g., empty extracts, file I/O, schema/type differences).
> 
> **Overview**
> Adds a **Parquet landing/staging step** between CFPB API extraction and DuckDB loading: `save_to_parquet()` writes extracted complaints to `landing/cfpb_complaints/{company}_{date_min}_{date_max}.parquet` (with basic filename sanitization), and `load_parquet_to_duckdb()` reads that file and loads via dlt using the existing merge-by-`complaint_id` behavior.
> 
> Refactors the Prefect flow to split the prior per-company extract+load into two tasks (`extract_to_parquet_task` then `load_parquet_to_duckdb_task`) and to skip the load when no records were extracted. Updates `.gitignore` to ignore `landing/*` (keeping `.gitkeep`) and adds docs describing the new PyArrow/Parquet staging approach and updated workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 539fdc04692dc420ecb63bdd9e17db8ff04819f7. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->