### PR TITLE
feat: Add daily landing directories and backfill script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,34 @@ uv run python run_prefect_flow.py
 uv run python run_prefect_flow.py --reset-state
 ```
 
-### 1.4 Access Prefect UI (Optional)
+### 1.4 Backfill Landing Area
+
+The landing area stores daily parquet files under `landing/cfpb_complaints/YYYY_MM_DD/`, one file per company per day. Use the backfill script to populate historical data:
+
+```bash
+# Backfill a date range
+uv run python run_backfill.py --start 2026-01-01 --end 2026-02-25
+
+# Backfill last 7 days
+uv run python run_backfill.py --days 7
+
+# Backfill a single day
+uv run python run_backfill.py --start 2026-01-15 --end 2026-01-15
+```
+
+Each daily directory contains 10 parquet files (one per company). Empty parquet files are created for days with no complaints to maintain a consistent structure.
+
+```
+landing/cfpb_complaints/
+├── 2026_01_01/
+│   ├── jpmorgan_2026-01-01_2026-01-02.parquet
+│   ├── bank_of_america_2026-01-01_2026-01-02.parquet
+│   └── ...
+├── 2026_01_02/
+│   └── ...
+```
+
+### 1.5 Access Prefect UI (Optional)
 
 ```bash
 # Start Prefect server
@@ -54,7 +81,7 @@ uv run python run_prefect_flow.py --reset-state
 
 <img width="2562" height="1352" alt="image" src="https://github.com/user-attachments/assets/81c72031-f948-455c-8dc2-d7b2483ce747" />
 
-### 1.5 Access DuckDB UI
+### 1.6 Access DuckDB UI
 
 First, install the DuckDB CLI:
 
@@ -77,7 +104,7 @@ We need to add in our database path as follow:
 
 Additional docs: [DuckDB UI Documentation](https://duckdb.org/docs/api/cli/ui)
 
-### 1.6 Access Visivo Dashboards
+### 1.7 Access Visivo Dashboards
 
 Start the Visivo web server to view interactive dashboards:
 
@@ -110,7 +137,7 @@ Then open your browser to:
 
 Additional docs: [Visivo Documentation](docs/README_VISIVO.MD)
 
-### 1.7 Generate dbt Lineage Reports with Colibri
+### 1.8 Generate dbt Lineage Reports with Colibri
 
 Generate interactive data lineage reports to visualize how data flows through your dbt models:
 

--- a/run_backfill.py
+++ b/run_backfill.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Backfill the landing area with daily parquet files.
+
+Creates one directory per day under landing/cfpb_complaints/YYYY_MM_DD/
+with a parquet file per company (including empty files for days with no data).
+
+Usage:
+    # Backfill a date range
+    python run_backfill.py --start 2026-01-01 --end 2026-02-25
+
+    # Backfill a single day
+    python run_backfill.py --start 2026-01-15 --end 2026-01-15
+
+    # Backfill last 7 days
+    python run_backfill.py --days 7
+"""
+
+import argparse
+import logging
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from src.cfg.config import COMPANIES
+from src.pipelines.cfpb_complaints_pipeline import save_to_parquet
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def backfill(start_date: datetime, end_date: datetime) -> dict:
+    """
+    Backfill the landing area for a date range.
+
+    Args:
+        start_date: First day to backfill (inclusive).
+        end_date: Last day to backfill (inclusive).
+
+    Returns:
+        Summary dict with total_days, total_files, total_rows, and per-day details.
+    """
+    total_days = (end_date - start_date).days + 1
+    logger.info(
+        f"Backfilling {total_days} days ({start_date.date()} to {end_date.date()}) "
+        f"for {len(COMPANIES)} companies"
+    )
+
+    daily_results = []
+    current = start_date
+    while current <= end_date:
+        date_str = current.strftime("%Y-%m-%d")
+        next_day = (current + timedelta(days=1)).strftime("%Y-%m-%d")
+        day_label = current.strftime("%Y_%m_%d")
+
+        logger.info(f"--- {day_label} ---")
+        day_files = []
+        for company in COMPANIES:
+            result = save_to_parquet(
+                date_received_min=date_str,
+                date_received_max=next_day,
+                company_name=company,
+                landing_date=date_str,
+            )
+            day_files.append(result)
+            logger.info(f"  {company}: {result}")
+
+        daily_results.append({"date": day_label, "files": len(day_files)})
+        current += timedelta(days=1)
+
+    total_files = total_days * len(COMPANIES)
+    logger.info(f"Backfill complete: {total_days} days, {total_files} files")
+    return {
+        "total_days": total_days,
+        "total_files": total_files,
+        "daily_results": daily_results,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Backfill landing area with daily parquet files",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  uv run python run_backfill.py --start 2026-01-01 --end 2026-02-25
+  uv run python run_backfill.py --start 2026-01-15 --end 2026-01-15
+  uv run python run_backfill.py --days 7
+        """,
+    )
+    parser.add_argument(
+        "--start",
+        type=str,
+        help="Start date inclusive (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--end",
+        type=str,
+        default=datetime.now().strftime("%Y-%m-%d"),
+        help="End date inclusive (YYYY-MM-DD, default: today)",
+    )
+    parser.add_argument(
+        "--days",
+        type=int,
+        help="Backfill the last N days (alternative to --start)",
+    )
+
+    args = parser.parse_args()
+
+    if args.days:
+        end_date = datetime.strptime(args.end, "%Y-%m-%d")
+        start_date = end_date - timedelta(days=args.days - 1)
+    elif args.start:
+        start_date = datetime.strptime(args.start, "%Y-%m-%d")
+        end_date = datetime.strptime(args.end, "%Y-%m-%d")
+    else:
+        parser.error("Either --start or --days is required")
+
+    if start_date > end_date:
+        parser.error(f"Start date {start_date.date()} is after end date {end_date.date()}")
+
+    backfill(start_date, end_date)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/orchestration/cfpb_flows.py
+++ b/src/orchestration/cfpb_flows.py
@@ -14,9 +14,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from prefect import flow, task
-
 import pyarrow.parquet as pq
+from prefect import flow, task
 
 from ..cfg.config import COMPANIES, START_DATE
 from ..pipelines.cfpb_complaints_pipeline import load_parquet_to_duckdb, save_to_parquet


### PR DESCRIPTION
## Summary
- Organize landing parquet files into daily directories (`landing/cfpb_complaints/YYYY_MM_DD/`) instead of a flat structure
- Always write a parquet file per company per day (empty files for days with no complaints) for consistent layout
- Add `run_backfill.py` CLI script to populate historical landing data with `--start/--end` or `--days` options
- Update README with backfill documentation and usage examples

## Test plan
- [x] Backfilled 55 days (Jan 1 – Feb 24) successfully: 550 files, 53,257 rows
- [x] Verified every daily directory contains exactly 10 files (one per company)
- [x] Verified empty parquet files are created for companies with no complaints
- [x] Verified `run_backfill.py --help` shows correct usage
- [x] Verified incremental flow (`run_prefect_flow.py`) still works with new directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ingestion semantics to always write (possibly empty) parquet files and alters the Prefect flow’s no-data detection, which could impact incremental loads or downstream expectations of parquet schema/contents.
> 
> **Overview**
> Moves landing output to a **daily directory layout** (`landing/cfpb_complaints/YYYY_MM_DD/`) and changes `save_to_parquet` to **always write a parquet per company per day**, emitting an empty parquet (with an `_empty` column) when no complaints are returned and allowing the directory date to be overridden via a new `landing_date` parameter.
> 
> Adds a new CLI (`run_backfill.py`) to backfill historical daily landing files across a date range or “last N days”, and updates the Prefect incremental flow to treat “no data” as **0 parquet rows** (via `pyarrow.parquet`) rather than `None`/missing output. README is updated with backfill instructions and renumbered setup sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e73b11d2b1be492e7b351589f4995f93e05f6dd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->